### PR TITLE
Use GHC.Types.SPEC to fix compilation with shared:False

### DIFF
--- a/Data/Generics/Uniplate/Internal/Utils.hs
+++ b/Data/Generics/Uniplate/Internal/Utils.hs
@@ -22,8 +22,11 @@ import GHC.IO(IO(IO))
 #endif
 #endif
 
-#if __GLASGOW_HASKELL__ >= 701
+#if __GLASGOW_HASKELL__ >= 708
+import GHC.Types ( SPEC(..) )
+#elif __GLASGOW_HASKELL__ >= 701
 import GHC.Exts(SpecConstrAnnotation(..))
+data SPEC = SPEC | SPEC2
 {-# ANN type SPEC ForceSpecConstr #-}
 #endif
 
@@ -53,7 +56,3 @@ inlinePerformIO = unsafePerformIO
 -- | Perform concatentation of continuations
 concatCont :: [a -> a] -> a -> a
 concatCont xs rest = foldr ($) rest xs
-
-
--- | Constructor specialisation on newer GHC
-data SPEC = SPEC | SPEC2

--- a/uniplate.cabal
+++ b/uniplate.cabal
@@ -58,7 +58,7 @@ flag separate_syb
 library
     if flag(typeable_fingerprint)
         build-depends:
-            base >=4.4 && <5, containers, syb,
+            base >=4.4 && <5, containers, ghc-prim, syb,
             hashable >= 1.1.2.3 && < 1.3,
             unordered-containers >= 0.2.1 && < 0.3
     else


### PR DESCRIPTION
This fixes https://ghc.haskell.org/trac/ghc/ticket/8618, and allows uniplate to be installed when `shared:False` is set in `~/.cabal`.

Edit: some more background information.

From compiler/specialise/SpecConstr.hs in the ghc repository:

```
Note [Forcing specialisation]
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

With stream fusion and in other similar cases, we want to fully
specialise some (but not necessarily all!) loops regardless of their
size and the number of specialisations.

We allow a library to do this, in one of two ways (one which is
deprecated):

  1) Add a parameter of type GHC.Types.SPEC (from ghc-prim) to the loop body.

  2) (Deprecated) Annotate a type with ForceSpecConstr from GHC.Exts,
     and then add *that* type as a parameter to the loop body

The reason #2 is deprecated is because it requires GHCi, which isn't
available for things like a cross compiler using stage1.
```

So the issue here goes something like this:
- uniplate used `ForceSpecConstr`
- `ForceSpecConstr` requires GHCi to run
- since ghc-7.8, GHCi requires shared libraries to be built
- `shared:false` disables building shared libraries
- error

This commit changes `uniplate` to use `GHC.Types.SPEC` instead of `ForceSpecConstr`, as suggested by that `Note`.

GHC.Types.SPEC was added to ghc-prim 0.3.1.0 / GHC 7.8.1 [1]. It's magic is partially explained in [2]. I made a similar pull request for vector in [3].

[1] https://downloads.haskell.org/~ghc/7.8.1/docs/html/users_guide/release-7-8-1.html
[2] http://git.haskell.org/ghc.git/commitdiff/cee3adbcc180bdf1be8b24aeaafa2ca4a737cbbf
[3] https://github.com/haskell/vector/pull/83
